### PR TITLE
Gallery Upload now opens correct activity layout and is now present in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,9 @@
             android:name=".CameraActivity"
             android:exported="false" />
         <activity
+            android:name=".GalleryActivity"
+            android:exported="false" />
+        <activity
             
             android:name=".AnimalInfo"
 

--- a/app/src/main/java/com/example/cse3310project/GalleryActivity.java
+++ b/app/src/main/java/com/example/cse3310project/GalleryActivity.java
@@ -33,7 +33,7 @@ public class GalleryActivity extends AppCompatActivity
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_camera);
+        setContentView(R.layout.activity_gallery_upload);
         setTitle("Gallery Upload");
         picView = findViewById(R.id.myImage);
         button = findViewById(R.id.uploadButton);


### PR DESCRIPTION
- Gallery Upload setContentView now set to activity_gallery_upload
- GalleryUpload no longer missing from androidmanifest.xml, which causes crashes